### PR TITLE
Refactor DNS record update logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 				currentPublicIP,
 			)
 		}
-	} else {
+	} else if zoneRecord[0].Content != currentPublicIP {
 		_, errorOccurred = apiClient.UpdateDNSRecord(
 			ctx, cloudflareZoneID, cloudflare.UpdateDNSRecordParams{
 				Name:    cloudflareDNSRecord,
@@ -92,6 +92,12 @@ func main() {
 				currentPublicIP,
 			)
 		}
+	} else {
+		log.Printf(
+			"No update required: '%s' is already resolving to %s",
+			cloudflareDNSRecord,
+			currentPublicIP,
+		)
 	}
 }
 


### PR DESCRIPTION
This commit refactors the logic for updating DNS records. Now, the application will only attempt to update the DNS record if the current public IP address is different from the existing record. If no update is required, a log message is generated to indicate that the record is already correctly configured.