### PR TITLE
Add cron scheduling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module dynmcdns-cldflr
 
 go 1.21
 
-require github.com/cloudflare/cloudflare-go v0.77.0
+require (
+	github.com/cloudflare/cloudflare-go v0.77.0
+	github.com/robfig/cron/v3 v3.0.1
+)
 
 require (
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=


### PR DESCRIPTION
This commit refactors the code to work with the cron scheduling library.

The main changes include the following:

- Moved the core logic into a cron job that runs at a specified interval.
- Added a "POLLING_INTERVAL" environment variable that stores the interval (in minutes).
- Logging statements to indicate the start of the application and cron job.
- Using the "runtime.Goexit()" function to keep the application alive indefinitely.
- Introduced a stringPointer utility function for string pointer creation.