### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.21
+
+LABEL maintainer="Nicholas Arvelo nicholas@arvelo.dev"
+LABEL com.na_ddns.version="1.0"
+LABEL com.na_ddns.description="na.DDNS - Cloudflare Dynamic DNS Client"
+LABEL com.na_ddns.release-date="2023-10-01"
+
+WORKDIR /usr/src/na.ddns
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -v -o /usr/local/bin/na.ddns ./...
+
+CMD ["na.ddns"]
+


### PR DESCRIPTION
This Dockerfile builds the 'na.DDNS' Cloudflare dynamic DNS client Golang binary within a Docker container which executed when the container starts.

The base golang:1.21 image is pretty chonky, though. So I may switch to Alpine at some point down the line.