### PR TITLE
Restrict record type

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,8 +28,10 @@ func main() {
 	}
 
 	cloudflareDNSRecordType := os.Getenv("CLOUDFLARE_DNS_RECORD_TYPE")
-	if cloudflareDNSRecordType == "" {
+	if cloudflareDNSRecordType == "" || cloudflareDNSRecordType == "AAAA" {
 		cloudflareDNSRecordType = "A"
+	} else {
+		log.Fatalln("'CLOUDFLARE_DNS_RECORD_TYPE' must be 'A'")
 	}
 
 	pollingInterval := os.Getenv("POLLING_INTERVAL")


### PR DESCRIPTION
This commit adds a restriction on the allowed values for 'CLOUDFLARE_DNS_RECORD_TYPE' until I add IPv6 support.