### PR TITLE
Update Dockerfile labels to Open Container Initiative (OCI) standards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 FROM golang:latest
-LABEL maintainer="nicholas@arvelo.dev"
 
 ARG BUILD_DATE
 ARG BUILD_VERSION
 
-LABEL org.label-schema.schema-version="1.0"
+LABEL org.opencontainers.created="$BUILD_DATE"
+LABEL org.opencontainers.version="$BUILD_VERSION"
 
-LABEL org.label-schema.build-date="$BUILD_DATE"
-LABEL org.label-schema.version="$BUILD_VERSION"
-
-LABEL org.label-schema.name="na.DDNS"
-LABEL org.label-schema.description="Cloudflare Dynamic DNS Client"
-LABEL org.label-schema.vcs-url="https://github.com/nicholasarvelo/na.DDNS"
+LABEL org.opencontainers.title="na.DDNS"
+LABEL org.opencontainers.image.authors="nicholas@arvelo.dev"
+LABEL org.opencontainers.description="Cloudflare Dynamic DNS Client"
+LABEL org.opencontainers.source="https://github.com/nicholasarvelo/na.DDNS"
 
 WORKDIR /usr/src/na.ddns
 


### PR DESCRIPTION
- Removed deprecated `org.label-schema` labels.
- Introduced `org.opencontainers` labels for build date, version, project title, author, description, and source URL.
- Removed the `maintainer` label as it is deprecated and replaced it with `org.opencontainers.image.authors`.