### PR TITLE
Add GitHub Actions workflow for Docker Buildx & Push

### DIFF
--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -1,0 +1,63 @@
+name: Docker Buildx & Push
+run-name: docker-buildx-push
+
+on:
+  pull_request:
+    types: ['closed']
+    branches: ['main']
+  push:
+    branches: ['main']
+    paths-ignore: ['**.md']
+    tags: ['v*']
+
+env:
+  CHECKOUT_FETCH_DEPTH: '0'
+  INITIAL_TAG_VERSION: '1.0'
+  TAG_BASE_NAME: 'steptimeeditor/na.ddns'
+
+jobs:
+  tag_version_bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+      - name: Github Tag Bump
+        uses: anothrNick/github-tag-action@1.67.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INITIAL_VERSION: ${{ env.INITIAL_TAG_VERSION }}
+          RELEASE_BRANCHES: main
+          WITH_V: true
+  docker_buildx:
+    runs-on: ubuntu-latest
+    needs: tag_version_bump
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5.0.0
+        with:
+          images: |
+            ${{ env.TAG_BASE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5.0.0
+        with:
+          context: .
+          labels: ${{ steps.metadata.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM golang:latest
 
-ARG BUILD_DATE
-ARG BUILD_VERSION
-
-LABEL org.opencontainers.created="$BUILD_DATE"
-LABEL org.opencontainers.version="$BUILD_VERSION"
-
 LABEL org.opencontainers.title="na.DDNS"
 LABEL org.opencontainers.image.authors="nicholas@arvelo.dev"
 LABEL org.opencontainers.description="Cloudflare Dynamic DNS Client"


### PR DESCRIPTION
- Created a new workflow 'docker-buildx-push.yml' in the '.github/workflows' directory.
- Configured the workflow to trigger on pull requests and pushes to the 'main' branch (excluding markdown files) and on new tags matching the 'v*' pattern.
- Set up QEMU and Docker Buildx for cross-platform builds.
- Added Docker Metadata action to generate tags based on semantic versioning and Git references.
- Implemented Docker Hub login using secrets for secure authentication.
- Configured the build and push step to push images only on non-pull request events.