### PR TITLE
Trigger tag version bump only on merged PRs and specify ref

### DIFF
--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -17,22 +17,22 @@ env:
 
 jobs:
   tag_version_bump:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: ${{ env.CHECKOUT_FETCH_DEPTH }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Github Tag Bump
         uses: anothrNick/github-tag-action@1.67.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INITIAL_VERSION: ${{ env.INITIAL_TAG_VERSION }}
-          RELEASE_BRANCHES: main
           WITH_V: true
   docker_buildx:
     runs-on: ubuntu-latest
-    needs: tag_version_bump
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0


### PR DESCRIPTION
- Add condition to run tag_version_bump job only for merged PRs
- Specify merge_commit_sha as ref for checkout in tag_version_bump
- Remove explicit dependency on tag_version_bump in docker_buildx job