### PR TITLE
Update initial tag version in bump-git-tag workflow

### DIFF
--- a/.github/workflows/bump-git-tag.yml
+++ b/.github/workflows/bump-git-tag.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  INITIAL_TAG_VERSION: '1.0'
+  INITIAL_TAG_VERSION: '1.1'
   PREFIX_TAG: true
   PRERELEASE_MODE: true
   RELEASE_BRANCH: "main"


### PR DESCRIPTION
The `INITIAL_TAG_VERSION` environment variable in the `bump-git-tag.yml` workflow has been updated from '1.0' to '1.1' to reflect the new initial versioning.