### PR TITLE
Set workflow to manual trigger

### DIFF
--- a/.github/workflows/docker-buildx-push.yml
+++ b/.github/workflows/docker-buildx-push.yml
@@ -1,14 +1,7 @@
 name: Docker Buildx & Push
 run-name: docker-buildx-push
 
-on:
-  pull_request:
-    types: ['closed']
-    branches: ['main']
-  push:
-    branches: ['main']
-    paths-ignore: ['**.md']
-    tags: ['v*']
+on: workflow_dispatch
 
 env:
   CHECKOUT_FETCH_DEPTH: '0'


### PR DESCRIPTION
This is prevent superfluous builds while troubleshooting.