### PR TITLE
ci(workflow): define a `run-name`

### DIFF
--- a/.github/workflows/bump-tag-and-release-versions.yml
+++ b/.github/workflows/bump-tag-and-release-versions.yml
@@ -1,4 +1,5 @@
 name: Bump GitHub Tag & Release Versions
+run-name: bump-tag-and-release-versions
 
 on:
   push:


### PR DESCRIPTION
Add run-name to the GitHub Tag & Release Versions workflow for clearer comprehension of workflow history.