### PR TITLE
ci(workflows): remove pull request condition from docker build workflows

### DIFF
--- a/.github/workflows/generate-build-id.yml
+++ b/.github/workflows/generate-build-id.yml
@@ -24,7 +24,6 @@ jobs:
       build_id: ${{ format('build-{0}-{1}', steps.generate-build-id.outputs.build_number, env.CURRENT_EPOCH_TIME) }}
 
   call-docker-buildx-and-push-workflow:
-    if: github.event_name == 'pull_request'
     needs: generate-build-id
     uses: './.github/workflows/docker-buildx-and-push.yml'
     with:

--- a/.github/workflows/generate-git-metadata.yml
+++ b/.github/workflows/generate-git-metadata.yml
@@ -35,7 +35,6 @@ jobs:
           body: ${{ steps.bump_tag_version.outputs.changelog }}
 
   call-docker-buildx-and-push-workflow:
-    if: github.event_name == 'pull_request'
     uses: './.github/workflows/docker-buildx-and-push.yml'
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
- Removed the condition checking for pull_request event in the call-docker-buildx-and-push-workflow job of the generate-build-id.yml and generate-git-metadata.yml workflows. This ensures that the docker build and push process is executed irrespective of the event type.