### PR TITLE
feat(github-workflows): integrate Release ID in CI Pipeline for Docker Builds

### DIFF
--- a/.github/workflows/docker-buildx-and-push.yml
+++ b/.github/workflows/docker-buildx-and-push.yml
@@ -12,6 +12,10 @@ on:
         description: 'The name of the caller workflow.'
         required: true
         type: string
+      RELEASE_ID:
+        description: 'The identifier of the created release.'
+        required: false
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         required: true

--- a/.github/workflows/generate-git-metadata.yml
+++ b/.github/workflows/generate-git-metadata.yml
@@ -28,16 +28,21 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fetch_all_tags: ${{ env.FETCH_ALL }}
       - name: Create a GitHub Release
+        id: create-release-id
         uses: ncipollo/release-action@v1.13.0
         with:
           tag: ${{ steps.bump_tag_version.outputs.new_tag }}
           name: Release ${{ steps.bump_tag_version.outputs.new_tag }}
           body: ${{ steps.bump_tag_version.outputs.changelog }}
+    outputs:
+      release_id: steps.create-release-id.outputs.id
 
   call-docker-buildx-and-push-workflow:
+    needs: generate-git-metadata
     uses: './.github/workflows/docker-buildx-and-push.yml'
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       CALLER_NAME: 'generate-git-metadata'
+      RELEASE_ID: $ {{ needs.generate-git-metadata.outputs.release_id }}


### PR DESCRIPTION
The intent of this change is to ensure that a Release ID is created before attempting to build and publish a new container image.

Changes made:

- Added an ID to the 'Create a GitHub Release' step.
- This ID is referenced by a new output 'release_id' when capturing the ID of the created release
- Added a new 'RELEASE_ID' input which receives the value of 'release_id' from 'generate-git-metadata.yml'.